### PR TITLE
Update tools to have two rpms for chkconfig or systemctl

### DIFF
--- a/SOURCES/0019-Fix-paths-in-xe-linux-distribution.service-for-XCP-n.patch
+++ b/SOURCES/0019-Fix-paths-in-xe-linux-distribution.service-for-XCP-n.patch
@@ -1,0 +1,29 @@
+From 37324de21746f342fdf303eca01f9c494932d0cb Mon Sep 17 00:00:00 2001
+From: Gael Duperrey <gduperrey@vates.fr>
+Date: Thu, 25 Aug 2022 09:18:23 +0200
+Subject: [PATCH 19/19] Fix paths in xe-linux-distribution.service for XCP-ng
+
+Signed-off-by: Gael Duperrey <gduperrey@vates.fr>
+---
+ mk/xe-linux-distribution.service | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mk/xe-linux-distribution.service b/mk/xe-linux-distribution.service
+index 4e60a85..ff692a2 100644
+--- a/mk/xe-linux-distribution.service
++++ b/mk/xe-linux-distribution.service
+@@ -3,8 +3,8 @@ Description=Linux Guest Agent
+ ConditionVirtualization=xen
+ 
+ [Service]
+-ExecStartPre=/usr/share/oem/xs/xe-linux-distribution /var/cache/xe-linux-distribution
+-ExecStart=/usr/share/oem/xs/xe-daemon
++ExecStartPre=/usr/sbin/xe-linux-distribution /var/cache/xe-linux-distribution
++ExecStart=/usr/sbin/xe-daemon
+ 
+ [Install]
+ WantedBy=multi-user.target
+\ No newline at end of file
+-- 
+2.37.1
+

--- a/SOURCES/0020-Update-install.sh-to-manage-two-rpm.patch
+++ b/SOURCES/0020-Update-install.sh-to-manage-two-rpm.patch
@@ -1,0 +1,42 @@
+From 658ead456dd78c2db9b31c65933ed4bd34da2398 Mon Sep 17 00:00:00 2001
+From: Gael Duperrey <gduperrey@vates.fr>
+Date: Wed, 7 Sep 2022 16:36:57 +0200
+Subject: [PATCH 20/20] Update install.sh to manage two rpm
+
+Signed-off-by: Gael Duperrey <gduperrey@vates.fr>
+---
+ mk/install.sh | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/mk/install.sh b/mk/install.sh
+index ac75e0f..c00b977 100755
+--- a/mk/install.sh
++++ b/mk/install.sh
+@@ -104,13 +104,18 @@ failure()
+ select_rpm_utilities()
+ {
+     if [ -f "${DATADIR}/versions.rpm" ] ; then
+-	source ${DATADIR}/versions.rpm
+-	XGU=
+-	for p in $(eval echo \${XE_GUEST_UTILITIES_PKG_FILE_${ARCH}}) ; do
+-	    XGU="$XGU ${DATADIR}/${p}"
+-	done
++        source ${DATADIR}/versions.rpm
++        XGU=
++        if command -v systemctl >/dev/null 2>&1; then
++            LEGACY=
++        else
++            LEGACY="LEGACY_"
++        fi
++        for p in $(eval echo \${XE_GUEST_UTILITIES_PKG_FILE_${LEGACY}${ARCH}}) ; do
++            XGU="$XGU ${DATADIR}/${p}"
++        done
+     else
+-	echo "Warning: Guest utilities not found in ${DATADIR}."
++        echo "Warning: Guest utilities not found in ${DATADIR}."
+     fi
+ }
+ 
+-- 
+2.37.2
+

--- a/SOURCES/xe-guest-utilities-legacy.spec
+++ b/SOURCES/xe-guest-utilities-legacy.spec
@@ -10,7 +10,6 @@ Release: %{xgu_release}.legacy
 License: BSD
 Group: Xen
 URL: https://github.com/xcp-ng/xe-guest-utilities
-Obsoletes: xe-guest-utilities < 7.30.0
 
 Source0: xe-linux-distribution
 Source1: xe-linux-distribution.init
@@ -23,18 +22,13 @@ Requires(post): chkconfig
 Requires(preun): chkconfig
 Requires(postun): chkconfig
 
+Obsoletes: xe-guest-utilities < 7.30.0
+Obsoletes: xe-guest-utilities-xenstore < 7.30.0-11
+
 %description
-Scripts for monitoring Virtual Machine.
+Scripts for monitoring Virtual Machines and utilities for interacting with XenStore.
 
 Writes distribution version information and IP address to XenStore.
-
-%package xenstore
-
-Summary: Virtual Machine XenStore utilities
-%description xenstore
-Utilities for interacting with XenStore from within a Xen Virtual Machine
-
-Obsoletes: xe-guest-utilities-xenstore < 7.30.0
 
 %install
 install -d %{buildroot}/usr/sbin/
@@ -81,8 +75,6 @@ fi
 /usr/sbin/xe-daemon
 /etc/udev/rules.d/z10-xen-vcpu-hotplug.rules
 /usr/share/doc/%{name}-%{version}/LICENSE
-
-%files xenstore
 /usr/bin/xenstore-*
 /usr/bin/xenstore
 

--- a/SOURCES/xe-guest-utilities.spec
+++ b/SOURCES/xe-guest-utilities.spec
@@ -19,16 +19,12 @@ Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 
+Obsoletes: xe-guest-utilities-xenstore < 7.30.0-11
+
 %description
-Scripts for monitoring Virtual Machine.
+Scripts for monitoring Virtual Machines and utilities for interacting with XenStore.
 
 Writes distribution version information and IP address to XenStore.
-
-%package xenstore
-
-Summary: Virtual Machine XenStore utilities
-%description xenstore
-Utilities for interacting with XenStore from within a Xen Virtual Machine
 
 %install
 install -d %{buildroot}/usr/sbin/
@@ -95,8 +91,6 @@ systemctl daemon-reload >/dev/null 2>&1 ||:
 /etc/udev/rules.d/z10-xen-vcpu-hotplug.rules
 /usr/share/doc/%{name}-%{version}/LICENSE
 /usr/lib/systemd/system/xe-linux-distribution.service
-
-%files xenstore
 /usr/bin/xenstore-*
 /usr/bin/xenstore
 

--- a/SPECS/xcp-ng-pv-tools.spec
+++ b/SPECS/xcp-ng-pv-tools.spec
@@ -263,6 +263,7 @@ install -D -m755 %{SOURCE3} %{buildroot}/opt/xensource/libexec/unmount_xstools.s
 %changelog
 * Tue Sep 12 2022 Gael Duperrey <gduperrey@vates.fr> - 8.2.0-11
 - Switch RPMs to systemd by default and provide legacy RPMs for chkconfig.
+- Merge separate -xenstore RPMs back into xe-guest-utilities RPMs
 
 * Tue Aug 02 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.2.0-10
 - Sync to latest upstream master: v7.30.0 + 10 commits


### PR DESCRIPTION
Modify the rpm generation process. We currently have a regular rpm for systems with systemctl and a legacy one for older systems with simply chkconfig. The EXTERNAL_P2V variable in the spec file has been deleted because it appears to be no longer in use.

Signed-off-by: Gael Duperrey <gduperrey@vates.fr>