### PR TITLE
Update WinPV 9.1.100

### DIFF
--- a/SOURCES/xcpng-winpv-9.0.9137.0-Release-x64.zip
+++ b/SOURCES/xcpng-winpv-9.0.9137.0-Release-x64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e13f64f10b11902364d3e031c8e37785d07d21262f3ca2d65b9740be41864d3
-size 8157973

--- a/SOURCES/xcpng-winpv-9.1.100.0-Release-x64.zip
+++ b/SOURCES/xcpng-winpv-9.1.100.0-Release-x64.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d2e7c7e5c1b6e328d462599235da505cb3ca00da7c61a7360d86e489a746a70
+size 13887507

--- a/SPECS/xcp-ng-pv-tools.spec
+++ b/SPECS/xcp-ng-pv-tools.spec
@@ -4,6 +4,9 @@
 %define xgu_micro 0
 %define xgu_version %{xgu_major}.%{xgu_minor}.%{xgu_micro}
 
+# Inside the WinPV zip, files are packed inside a directory of the same name.
+%define winpv_version_x64 xcpng-winpv-9.1.100.0-Release-x64
+
 # xcp-ng-pv-tools is versioned after the release of XCP-ng it was made for
 # Only X.Y (eg. 8.3, not 8.3.0)
 %define xcp_ng_release 8.3
@@ -13,7 +16,7 @@ Version: %{xcp_ng_release}
 # xe-guest-utilies is versioned after the RPM release, so we need to keep it upwards,
 # without reinitializing it to 1 when the RPM version changes.
 # Try to keep this in sync with other XCP-ng releases.
-%define _release 14
+%define _release 15
 Release: %{_release}%{?dist}
 
 # The xe-guest-utilities release is the xcp-ng-pv-tools release
@@ -51,7 +54,7 @@ Source15: debian-postrm
 Source16: debian-prerm
 Source17: debian-rules
 
-Source100: xcpng-winpv-9.0.9137.0-Release-x64.zip
+Source100: %{winpv_version_x64}.zip
 
 Patch0: LICENSE.patch
 
@@ -233,8 +236,8 @@ build_and_copy_deb i386
 
 # *** Build the ISO ***
 install -m 0644 %{SOURCE1} iso/README.txt
-unzip %{SOURCE100} 'package/*' -d iso/
-mv iso/package iso/Windows
+unzip %{SOURCE100} '*/package/*'
+cp -r -T %{winpv_version_x64}/package iso/Windows
 install -m 0644 versions.tgz versions.rpm versions.deb iso/Linux/
 install -m 0755 mk/install.sh \
                 mk/xe-linux-distribution \
@@ -274,6 +277,9 @@ install -D -m755 %{SOURCE3} %{buildroot}/opt/xensource/libexec/unmount_xstools.s
 /opt/xensource/libexec/unmount_xstools.sh
 
 %changelog
+* Mon Dec 08 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 8.3-15
+- Add XCP-ng Windows PV tools version 9.1.100.0 Release Signed
+
 * Fri Nov 14 2025 Gael Duperrey <gduperrey@vates.tech> - 8.3-14
 - Remove noise from patches using git-format-patch options
 - Add patch to remove the invitation to reboot after install of the tools


### PR DESCRIPTION
The WinPV unpacking process had to be slightly changed, since I'm using the unmodified release ZIP this time.

To be released after Dec 12 2025 to take the WinPV test period into account.

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-2626

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

Update WinPV 9.1.100 with the following changes:
- **NEW**: Add installer option to disable time sync.
- **Improved**: Better cleanup of Xenbus devices.
- **Fixes**: Driver symbols are now back after an accidental omission in 9.0.9137.
- **Fixes**: Fix restoration of network settings after uninstallation.
- **Fixes**: Fix XenClean in Safe Mode.
- **Fixes**: Fix system time drifting when time sync is enabled.
- **Fixes**: Fix display of Windows OS version.
- **Fixes**: Fix Xen Guest Agent reporting after VM resume and migration.
- **Fixes**: Fix receive-side scaling.
- **Fixes**: Various driver stability fixes.

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

- Update to XCP-ng Windows PV Tools 9.1.100.0
- Bug fixes to the Windows PV network driver, guest agent and installer

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [x] No

_If yes, provide details._

N/A; usual upgrade procedure applies

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

guest_tools/win (https://github.com/xcp-ng/xcp-ng-tests/pull/348) on Server 2016 and 2025, with upgrade from 9.0.9137.

A test period of 2 weeks (ending Dec 12) is also applied.

_2. Regarding potential regressions._

Same as above

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

guest_tools/win

_2. Regarding potential regressions._

guest_tools/win

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

https://github.com/xcp-ng/xcp-ng-tests/pull/348

_2. To ensure there are no regressions._

Same as above

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

Verify that upgrades from 9.0.9137 work normally
Verify that NIC RSS works (`Get-NetAdapterRss` provides a non-zero MaxProcessors)
Verify that uninstallation restores the NIC settings
Verify that guest OS and guest agent information are restored after migrating/resuming the VM

(The above should already be covered by the linked test branch)

_2. Regarding potential regressions._

Upgrade from 9.0.9137 happens with no issues

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [x] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

N/A

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A