### PR TITLE
Update WinPV 9.1.146

### DIFF
--- a/SOURCES/xcpng-winpv-9.1.100.0-Release-x64.zip
+++ b/SOURCES/xcpng-winpv-9.1.100.0-Release-x64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d2e7c7e5c1b6e328d462599235da505cb3ca00da7c61a7360d86e489a746a70
-size 13887507

--- a/SOURCES/xcpng-winpv-9.1.146.0-Release-x64.zip
+++ b/SOURCES/xcpng-winpv-9.1.146.0-Release-x64.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34d2fdf30b2ecd8ec471054ba77a843da0e24e1dfd64c9fb36528a130f6d3a6c
+size 12843880

--- a/SPECS/xcp-ng-pv-tools.spec
+++ b/SPECS/xcp-ng-pv-tools.spec
@@ -5,7 +5,7 @@
 %define xgu_version %{xgu_major}.%{xgu_minor}.%{xgu_micro}
 
 # Inside the WinPV zip, files are packed inside a directory of the same name.
-%define winpv_version_x64 xcpng-winpv-9.1.100.0-Release-x64
+%define winpv_version_x64 xcpng-winpv-9.1.146.0-Release-x64
 
 # xcp-ng-pv-tools is versioned after the release of XCP-ng it was made for
 # Only X.Y (eg. 8.3, not 8.3.0)
@@ -16,7 +16,7 @@ Version: %{xcp_ng_release}
 # xe-guest-utilies is versioned after the RPM release, so we need to keep it upwards,
 # without reinitializing it to 1 when the RPM version changes.
 # Try to keep this in sync with other XCP-ng releases.
-%define _release 15
+%define _release 16
 Release: %{_release}%{?dist}
 
 # The xe-guest-utilities release is the xcp-ng-pv-tools release
@@ -277,6 +277,9 @@ install -D -m755 %{SOURCE3} %{buildroot}/opt/xensource/libexec/unmount_xstools.s
 /opt/xensource/libexec/unmount_xstools.sh
 
 %changelog
+* Tue Mar 17 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 8.3-16
+- Add XCP-ng Windows PV tools version 9.1.146.0 Release
+
 * Mon Dec 08 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 8.3-15
 - Add XCP-ng Windows PV tools version 9.1.100.0 Release Signed
 


### PR DESCRIPTION
To be released after Apr 3 2026 to take the WinPV test period into account.

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-3067

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

Update WinPV 9.1.146 with the following changes:
- **NEW**: The XCP-ng Standard VGA Display Driver is now included in the package.
- **Improved**: XenClean is now a single executable that's more convenient to use.
- **Improved**: Better uninstalling of existing drivers.
- **Fixed**: **Automatic time sync is now disabled by default. NTP sync with W32Time is recommended instead.**
- **Fixed**: Xen Guest Agent now supports driver restarts and upgrades.
- **Fixed**: Fix uninstallation of individual drivers.
- **Fixed**: Improved stability and efficiency of Xenbus and Xenvbd.

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

- Update to XCP-ng Windows PV Tools 9.1.146.0
- Include the XSTDVGA driver and improvements to the guest agent/installer

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [x] No

_If yes, provide details._

N/A; usual upgrade procedure applies

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

Tested on the following images:

```
windows-server-2016-autotest-2025-09
windows-server-2019-autotest-2025-09
windows-server-2022-autotest-2025-09
windows-server-core-2025-autotest-2026-03-v1
```

_2. Regarding potential regressions._

Same as above

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

guest_tools/win

_2. Regarding potential regressions._

guest_tools/win

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

https://github.com/xcp-ng/xcp-ng-tests/pull/409 (merged)
https://github.com/xcp-ng/xcp-ng-tests/pull/432

_2. To ensure there are no regressions._

None added this time

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

N/A

(The above should already be covered by the linked test branch)

_2. Regarding potential regressions._

Verify that upgrades from 9.1.100 work normally
Verify that guest agent works after resuming from suspend
Verify that the clipboard feature functions correctly
Verify that XenClean correctly removes drivers and tools

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [x] Yes
- [ ] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

https://github.com/xcp-ng/xcp-ng-org/pull/450

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A